### PR TITLE
Fix build and link to guide.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Tested on IE9, Chrome 46, Firefox 41 & Safari 7.1 using
 
 * [Quick start](http://www.js-data.io/docs/home#quick-start) - Get started in 5 minutes
 * [Guides and Tutorials](http://www.js-data.io/docs/home) - Learn how to use JSData
-* [`LocalStorageAdapter` Guide](http://www.js-data.io/docs/js-data-localstorage) - Learn how to use `LocalStorageAdapter`
+* [`LocalStorageAdapter` Guide](http://www.js-data.io/docs/dslocalstorageadapter) - Learn how to use `LocalStorageAdapter`
 * [API Reference Docs](http://api.js-data.io) - Explore components, methods, options, etc.
 * [Community & Support](http://js-data.io/docs/community) - Find solutions and chat with the community
 * [General Contributing Guide](http://js-data.io/docs/contributing) - Give back and move the project forward

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "js-data": "^3.0.0-beta.3"
   },
   "devDependencies": {
+    "babel-plugin-external-helpers": "^6.18.0",
     "babel-polyfill": "6.8.0",
     "babel-preset-es2015-rollup": "1.1.1",
     "js-data-adapter": "~0.6.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,18 @@ module.exports = {
   },
   plugins: [
     babel({
+      babelrc: false,
+      plugins: [
+        'babel-plugin-external-helpers'
+      ],
+      presets: [
+        [
+          'es2015',
+          {
+            modules: false
+          }
+        ]
+      ],
       exclude: ['node_modules/mout/**/*']
     }),
     nodeResolve({


### PR DESCRIPTION
`npm run build` was failing.

I've followed the [example config](https://github.com/js-data/js-data-repo-tools/blob/master/examples/rollup/rollup.config.js) in js-data-repo-tools.

Also a link to the documentation has been corrected in the `README.md`.