### PR TITLE
Update order of dependencies in example index. Fixes #42

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -7,8 +7,8 @@
   <link href="./example.css" rel="stylesheet">
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.25/angular.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-data/2.8.2/js-data.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/js-data-angular/3.1.0/js-data-angular.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/js-data-localstorage/2.1.3/js-data-localstorage.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/js-data-angular/3.1.0/js-data-angular.min.js"></script>
   <script src="./example.js"></script>
 </head>
 <body data-ng-controller="localStorageCtrl as lsCtrl">


### PR DESCRIPTION
Fixes #42 

This only includes a one line change in the example app.  The localStorage adapter needs to be loaded prior to the angular adapter for the example app to work.